### PR TITLE
Add test case for `null` and `undefined` values

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const entries = require('object.entries')
 function targetFor (source, destructive) {
   if (Array.isArray(source)) {
     return destructive ? source : []
-  } else if (typeof source === 'object') {
+  } else if (source !== null && typeof source === 'object') {
     return destructive ? source : {}
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,6 +6,10 @@ function reverse (input) {
   return input.split('').reverse().join('')
 }
 
+function identity (input) {
+  return input
+}
+
 function whenKeyMatches (expected, fn) {
   return (value, key) => {
     return key === expected ? fn(value) : value
@@ -196,6 +200,32 @@ tap.test('gracefully handle circular references', (t) => {
 
   // The expectation also needs a circular reference
   expected.foo.input = expected
+
+  t.deepEqual(input, expected, 'matches expected output')
+  t.end()
+})
+
+
+tap.test('supports null and undefined values', (t) => {
+  const input = {
+    foo: {
+      bar: {
+        baz: null
+      },
+      bux: undefined
+    }
+  }
+
+  breadthFilter(input, identity)
+
+  const expected = {
+    foo: {
+      bar: {
+        baz: null
+      },
+      bux: undefined
+    }
+  }
 
   t.deepEqual(input, expected, 'matches expected output')
   t.end()


### PR DESCRIPTION
Closes https://github.com/Qard/breadth-filter/issues/7.

I'd also love to get your take on this modules usage in https://github.com/elastic/apm-nodejs-http-client/pull/49, it seems it's hard to fix the data while you traverse since it's not called on object values. However, that module would like to change a value as you traverse resulting in a different output. What do you think of always calling `fn()` and then using `targetFor` on `fn`? This would also relegate the handling of mutable vs immutable onto the caller of this module - `fn()` could optionally mutate _or_ return in place.