### PR TITLE
Switch to esm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - 11
-  - 10
-  - 8
-  - 6
+  - 16

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install breadth-filter
 ## Example
 
 ```js
-const breadthFilter = require('breadth-filter')
+import breadthFilter from 'breadth-filter'
 
 const data = {
   user: {

--- a/index.js
+++ b/index.js
@@ -1,20 +1,14 @@
-const entries = require('object.entries')
+const entries = Object.entries
 
-function defaultOnArray () { return [] }
-function defaultOnObject () { return {} }
-
-function targetFor (source, key, fieldPath, isNew, {
-  onArray = defaultOnArray,
-  onObject = defaultOnObject
-} = {}) {
+function targetFor (source, key, fieldPath, isNew, opts) {
   if (Array.isArray(source)) {
-    return onArray(source, key, fieldPath, isNew)
+    return opts.onArray ? opts.onArray(source, key, fieldPath, isNew) : []
   } else if (source !== null && typeof source === 'object') {
-    return onObject(source, key, fieldPath, isNew)
+    return opts.onObject ? opts.onObject(source, key, fieldPath, isNew) : {}
   }
 }
 
-module.exports = function breadthFilter (root, opts = {}) {
+function breadthFilter (root, opts = {}) {
   const { onValue } = opts
   const target = targetFor(root, null, [], true, opts)
   if (!target) return root
@@ -44,3 +38,5 @@ module.exports = function breadthFilter (root, opts = {}) {
 
   return target
 }
+
+export default breadthFilter

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "breadth-filter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Breadth-first deep object filter",
   "author": "Stephen Belanger <admin@stephenbelanger.com> (https://github.com/qard)",
   "license": "MIT",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "tap test.js"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   },
   "keywords": [
     "breadth",
@@ -14,12 +18,6 @@
     "object",
     "filter"
   ],
-  "devDependencies": {
-    "tap": "^12.1.0"
-  },
-  "dependencies": {
-    "object.entries": "^1.0.4"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Qard/breadth-filter.git"
@@ -27,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/Qard/breadth-filter/issues"
   },
-  "homepage": "https://github.com/Qard/breadth-filter#readme"
+  "homepage": "https://github.com/Qard/breadth-filter#readme",
+  "dependencies": {
+    "tap": "^18.5.2"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-const tap = require('tap')
+import tap from 'tap'
 
-const breadthFilter = require('./')
+import breadthFilter from './index.js'
 
 function reverse (input) {
   return input.split('').reverse().join('')


### PR DESCRIPTION
your own package makes up for 4.7% while the rest are just dependencies (that are no longer needed)
this use native object.entries and removes 59 modules from 9 different developers.

https://npmgraph.js.org/?q=breadth-filter@2.0.0

(and also switches to esm while at it)